### PR TITLE
Compile flags are saved in `.gllvm_flags`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ develop:
 	go install github.com/SRI-CSL/gllvm/cmd/...
 
 
-check: develop
+deps:
+	sudo apt install clang llvm
+	touch $@
+
+check: develop deps
 	 go test -v ./tests
 
 format:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ develop:
 	go install github.com/SRI-CSL/gllvm/cmd/...
 
 
+
+dumpsections: check
+	readelf -x .gllvm_flags data/hello
+
 deps:
 	sudo apt install clang llvm
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,13 @@ deps:
 check: develop deps
 	 go test -v ./tests
 
+
+tests: develop deps
+	WLLVM_OUTPUT_LEVEL=DEBUG ; go test -v ./tests
+
 format:
 	gofmt -s -w shared/*.go tests/*.go cmd/*/*.go
 
 
 clean:
-	rm -f data/hello data/hello.bc [td]*/.helloworld.c.o [td]*/.helloworld.c.o.bc
+	rm -f data/hello data/helloworld data/hello.bc [td]*/.helloworld.c.o [td]*/.helloworld.c.o.bc

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ develop:
 
 dumpsections: 
 	readelf -x .gllvm_flags data/hello
+	readelf -x .gllvm_flags data/hello2
 
 deps:
 	sudo apt install clang llvm
@@ -23,4 +24,4 @@ format:
 
 
 clean:
-	rm -f data/hello data/hello data/helloworld data/hello.bc [td]*/.helloworld.c.o [td]*/.helloworld.c.o.bc
+	rm -f data/hello data/hello2 [td]*/.*.o [td]*/.*.bc [td]*/*.o

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
+
 develop:
 	go install github.com/SRI-CSL/gllvm/cmd/...
 
 
 
-dumpsections: check
+dumpsections: 
 	readelf -x .gllvm_flags data/hello
 
 deps:
@@ -11,15 +12,15 @@ deps:
 	touch $@
 
 check: develop deps
-	 go test -v ./tests
+	GLLVM_EMBED_FRONTEND_ARGS=true go test -v ./tests
 
 
 tests: develop deps
-	WLLVM_OUTPUT_LEVEL=DEBUG ; go test -v ./tests
+	WLLVM_OUTPUT_LEVEL=DEBUG GLLVM_EMBED_FRONTEND_ARGS=true go test -v ./tests
 
 format:
 	gofmt -s -w shared/*.go tests/*.go cmd/*/*.go
 
 
 clean:
-	rm -f data/hello data/helloworld data/hello.bc [td]*/.helloworld.c.o [td]*/.helloworld.c.o.bc
+	rm -f data/hello data/hello data/helloworld data/hello.bc [td]*/.helloworld.c.o [td]*/.helloworld.c.o.bc

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 <img align="center" src="data/dragon128x128.png?raw_true">
 </p>
 
+# Trail of Bits Fork Notes
+
+## Install and Compile
+```
+$ go get github.com/SRI-CSL/gllvm/cmd/...
+$ cd $GOPATH/src/github.com/SRI-CSL/gllvm
+$ git remote rename origin sri
+$ git remote add origin git@github.com:trailofbits/gllvm.git
+$ git pull origin master
+$ git branch --set-upstream-to=origin/master master
+
+# To compile
+$ make
+```
+
 # Whole Program LLVM in Go
 
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)

--- a/data/helloworld.c
+++ b/data/helloworld.c
@@ -1,8 +1,11 @@
 #include <stdio.h>
+#include "testobj.h"
 
 
 int main(int argc, char *argv[]) {
 
-  fprintf(stdout, "hello world");
+  fprintf(stdout, "hello world\n");
 
+  int testval = testobj_func1(41);
+  fprintf(stdout, "This value should be 42: %d\n", testval);
 }

--- a/data/testobj.c
+++ b/data/testobj.c
@@ -1,0 +1,3 @@
+int testobj_func1(int a) {
+    return a+1;
+}

--- a/data/testobj.h
+++ b/data/testobj.h
@@ -1,0 +1,1 @@
+int testobj_func1(int a);

--- a/shared/compiler.go
+++ b/shared/compiler.go
@@ -42,11 +42,22 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"encoding/json"
 )
 
 type bitcodeToObjectLink struct {
 	bcPath  string
 	objPath string
+}
+
+type buildFlags struct {
+	CompilerExecName string
+	Arguments        []string
+	Files            []string
+	ObjectFiles      []string
+	OutputFilename   string
+	CompileArgs      []string
+	LinkArgs         []string
 }
 
 //Compile wraps a call to the compiler with the given args.
@@ -131,7 +142,22 @@ func buildAndAttachBitcode(compilerExecName string, pr parserResult, bcObjLinks 
 }
 
 func buildFlagFile(compilerExecName string, pr parserResult) []byte {
-	return []byte("")
+	flags := &buildFlags {
+		CompilerExecName: compilerExecName,
+		Arguments: pr.InputList,
+		Files: pr.InputFiles,
+		ObjectFiles: pr.ObjectFiles,
+		OutputFilename: pr.OutputFilename,
+		CompileArgs: pr.CompileArgs,
+		LinkArgs: pr.LinkArgs,
+	}
+
+	flagsBytes, err := json.Marshal(flags)
+	if err!=nil {
+		LogError("buildFlagFile(): Unable to JSON encode parserResults")
+		return []byte("ERROR")
+	}
+	return []byte(flagsBytes)
 }
 
 func attachBitcodePathToObject(bcFile, objFile string, compilerExecName string, pr parserResult) (success bool) {

--- a/shared/compiler.go
+++ b/shared/compiler.go
@@ -172,7 +172,7 @@ func attachBitcodePathToObject(bcFile, objFile string, compilerExecName string, 
 			}
 			attachCmdArgs = []string{"-r", "-keep_private_externs", objFile, "-sectcreate", DarwinSegmentName, DarwinSectionName, tmpFile.Name()}
 
-			if LLVMAttachArgs {
+			if LLVMEmbedFrontendArgs {
 				tmpFlagFile, err := ioutil.TempFile("", "gllvm_flags")
 				if err != nil {
 					LogError("attachBitcodePathToObject: %v\n", err)
@@ -202,7 +202,7 @@ func attachBitcodePathToObject(bcFile, objFile string, compilerExecName string, 
 			}
 			attachCmdArgs = []string{"--add-section", ELFSectionName + "=" + tmpFile.Name()}
 
-			if LLVMAttachArgs {
+			if LLVMEmbedFrontendArgs {
 				tmpFlagFile, err := ioutil.TempFile("", "gllvm_flags")
 				if err != nil {
 					LogError("attachBitcodePathToObject: %v\n", err)

--- a/shared/compiler.go
+++ b/shared/compiler.go
@@ -211,11 +211,13 @@ func buildObjectFile(compilerExecName string, pr parserResult, srcFile string, o
 		return
 	}
 
-	flagContents := jsonEncodeFlags(objFile, compilerExecName, args, pr)
-	err = SectionWrite(objFile, flagContents, SectionNameFlags)
-	if err != nil {
-		LogError("buildObjectFile(): Unable to write section")
-		return false
+	if LLVMEmbedFrontendArgs {
+		flagContents := jsonEncodeFlags(objFile, compilerExecName, args, pr)
+		err = SectionWrite(objFile, flagContents, SectionNameFlags)
+		if err != nil {
+			LogError("buildObjectFile(): Unable to write section")
+			return false
+		}
 	}
 
 	success = true

--- a/shared/environment.go
+++ b/shared/environment.go
@@ -41,20 +41,20 @@ import (
 
 const (
 
-	//ELFSectionName is the name of our ELF section of "bitcode paths".
-	ELFSectionName = ".llvm_bc"
+	// SectionNameBitCode section of "bitcode paths"
+	SectionNameBitCode = "llvm_bc"
 
-	// ELFFrontendFlagsSectionName is the name of our ELF section of frontend flags for each translation unit
-	ELFFrontendFlagsSectionName = ".gllvm_flags"
+	// SectionNameFlags is the name of our ELF section of frontend flags for each translation unit
+	SectionNameFlags = "gllvm_flags"
 
 	//DarwinSegmentName is the name of our MACH-O segment of "bitcode paths".
 	DarwinSegmentName = "__WLLVM"
 
-	//DarwinSectionName is the name of our MACH-O section of "bitcode paths".
-	DarwinSectionName = "__llvm_bc"
+	// //DarwinSectionName is the name of our MACH-O section of "bitcode paths".
+	// DarwinSectionName = "__llvm_bc"
 
-	// DarwinFrontendFlagsSectionName is the name of our MACH-O section of frontend flags for each translation unit
-	DarwinFrontendFlagsSectionName = "__gllvm_flags"
+	// // DarwinFrontendFlagsSectionName is the name of our MACH-O section of frontend flags for each translation unit
+	// DarwinFrontendFlagsSectionName = "__gllvm_flags"
 )
 
 //LLVMToolChainBinDir is the user configured directory holding the LLVM binary tools.

--- a/shared/environment.go
+++ b/shared/environment.go
@@ -47,8 +47,8 @@ const (
 	// SectionNameFlags is the name of our ELF section of frontend flags for each translation unit
 	SectionNameFlags = "gllvm_flags"
 
-	//DarwinSegmentName is the name of our MACH-O segment of "bitcode paths".
-	DarwinSegmentName = "__WLLVM"
+	//SegmentNameDarwin is the name of our MACH-O segment of "bitcode paths".
+	SegmentNameDarwin = "__WLLVM"
 
 	// //DarwinSectionName is the name of our MACH-O section of "bitcode paths".
 	// DarwinSectionName = "__llvm_bc"

--- a/shared/environment.go
+++ b/shared/environment.go
@@ -93,8 +93,8 @@ var LLVMLd string
 //LLVMbcGen is the list of args to pass to clang during the bitcode generation step.
 var LLVMbcGen []string
 
-//LLVMAttachArgs flags whether or not we embed frontend arguments in each compiled object.
-var LLVMAttachArgs bool
+//LLVMEmbedFrontendArgs flags whether or not we embed frontend arguments in each compiled object.
+var LLVMEmbedFrontendArgs bool
 
 const (
 	envpath    = "LLVM_COMPILER_PATH"
@@ -115,7 +115,7 @@ const (
 
 	// 4/9/2020 new feature to embed the frontend compiler and linker flags
 	// passed to clang within each object
-	envattachargs = "GLLVM_ATTACH_FRONTEND_ARGS"
+	envembedargs = "GLLVM_EMBED_FRONTEND_ARGS"
 )
 
 func init() {
@@ -124,7 +124,7 @@ func init() {
 
 // PrintEnvironment is used for printing the aspects of the environment that concern us
 func PrintEnvironment() {
-	vars := []string{envpath, envcc, envcxx, envar, envlnk, envcfg, envbc, envlvl, envfile, envobjcopy, envld, envbcgen, envattachargs}
+	vars := []string{envpath, envcc, envcxx, envar, envlnk, envcfg, envbc, envlvl, envfile, envobjcopy, envld, envbcgen, envembedargs}
 
 	informUser("\nLiving in this environment:\n\n")
 	for _, v := range vars {
@@ -152,7 +152,7 @@ func ResetEnvironment() {
 	LLVMObjcopy = ""
 	LLVMLd = ""
 	LLVMbcGen = []string{}
-	LLVMAttachArgs = false
+	LLVMEmbedFrontendArgs = false
 }
 
 // FetchEnvironment is used in initializing our globals, it is also used in testing
@@ -175,8 +175,8 @@ func FetchEnvironment() {
 	LLVMbcGen = strings.Fields(os.Getenv(envbcgen))
 
 	var err error
-	LLVMAttachArgs, err = strconv.ParseBool(os.Getenv(envattachargs))
+	LLVMEmbedFrontendArgs, err = strconv.ParseBool(os.Getenv(envembedargs))
 	if err != nil {
-		LLVMAttachArgs = false
+		LLVMEmbedFrontendArgs = false
 	}
 }

--- a/shared/extractor.go
+++ b/shared/extractor.go
@@ -253,8 +253,7 @@ func resolveTool(defaultPath string, envPath string, usrPath string) (path strin
 
 func handleExecutable(ea ExtractionArgs) (success bool) {
 	// get the list of bitcode paths
-	sectionator := NewSectionator(ea.InputFile)
-	sectionData, err := sectionator.ReadSection(SectionNameBitCode)
+	sectionData, err := SectionRead(ea.InputFile, SectionNameBitCode)
 
 	if err != nil {
 		LogError("Unable to read section %s in %s.", SectionNameBitCode, ea.InputFile)
@@ -674,59 +673,14 @@ func linkBitcodeFiles(ea ExtractionArgs, filesToLink []string) (success bool) {
 	return
 }
 
-// func extractSectionDarwin(inputFile string) (contents []string) {
-// 	machoFile, err := macho.Open(inputFile)
-// 	if err != nil {
-// 		LogError("Mach-O file %s could not be read.", inputFile)
-// 		return
-// 	}
-// 	sectionName := platformizeSectionName(SectionNameBitCode)
-// 	section := machoFile.Section(sectionName)
-// 	if section == nil {
-// 		LogWarning("The %s section of %s is missing!\n", sectionName, inputFile)
-// 		return
-// 	}
-// 	sectionContents, errContents := section.Data()
-// 	if errContents != nil {
-// 		LogWarning("Error reading the %s section of Mach-O file %s.", sectionName, inputFile)
-// 		return
-// 	}
-// 	contents = strings.Split(strings.TrimSuffix(string(sectionContents), "\n"), "\n")
-// 	return
-// }
-
-// func extractSectionUnix(inputFile string) (contents []string) {
-// 	elfFile, err := elf.Open(inputFile)
-// 	if err != nil {
-// 		LogError("ELF file %s could not be read.", inputFile)
-// 		return
-// 	}
-// 	sectionName := platformizeSectionName(SectionNameBitCode)
-
-// 	section := elfFile.Section(sectionName)
-// 	if section == nil {
-// 		LogWarning("Error reading the %s section of ELF file %s.", sectionName, inputFile)
-// 		return
-// 	}
-// 	sectionContents, errContents := section.Data()
-// 	if errContents != nil {
-// 		LogWarning("Error reading the %s section of ELF file %s.", sectionName, inputFile)
-// 		return
-// 	}
-// 	contents = strings.Split(strings.TrimSuffix(string(sectionContents), "\n"), "\n")
-// 	return
-// }
-
 func extractBitCodePaths(inputFile string) (contents []string) {
-	sectionator := NewSectionator(inputFile)
-	data, err := sectionator.ReadSection(SectionNameBitCode)
+	data, err := SectionRead(inputFile, SectionNameBitCode)
 
 	if err != nil {
 		LogError("Unable to read section %s in %s.", SectionNameBitCode, inputFile)
 		return nil
 	}
 	contents = strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
-	fmt.Printf("ZZZ extractBitCodePaths(): %v\n", contents)
 	return contents
 }
 

--- a/shared/sections.go
+++ b/shared/sections.go
@@ -1,0 +1,149 @@
+//
+// ELF Section related code
+
+package shared
+
+import (
+	"debug/elf"
+	"debug/macho"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// type Sectionator struct {
+// 	Filename string
+// }
+
+// func NewSectionator(filename string) *Sectionator {
+// 	this := &Sectionator{
+// 		Filename: filename,
+// 	}
+// 	return this
+// }
+
+// data2file takes byte contents and writes them to a file
+func data2file(data []byte) (filepath *os.File, err error) {
+
+	tmpFile, err := ioutil.TempFile("", "data2file")
+	if err != nil {
+		return nil, fmt.Errorf("data2file(): Unable to create temp file")
+	}
+	defer tmpFile.Close()
+
+	_, err = tmpFile.Write(data)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to write data to %s", tmpFile.Name())
+	}
+	return tmpFile, nil
+}
+
+// SectionWrite writes data to sectionName of an elf or mach file
+func SectionWrite(filename string, data []byte, segmentName string, sectionName string) (err error) {
+	// We can only attach a bitcode path to certain file types
+	extension := filepath.Ext(filename)
+	switch extension {
+	case
+		".o",
+		".lo",
+		".os",
+		".So",
+		".po":
+	default:
+		return fmt.Errorf("Extension %s not supported", extension)
+	}
+
+	// Sanity checks
+	if len(segmentName) > 0 && runtime.GOOS != osDARWIN {
+		return fmt.Errorf("Segment name requires Mac OS")
+	}
+
+	if len(segmentName) == 0 && runtime.GOOS != osLINUX {
+		return fmt.Errorf("Empty segment is only compatible with Liux")
+	}
+
+	tmpFile, err := data2file(data)
+	if err != nil {
+		return fmt.Errorf("Unable to create temp file")
+	}
+	defer os.Remove(tmpFile.Name())
+
+	var attachCmd string
+	var attachCmdArgs []string
+	if runtime.GOOS == osDARWIN {
+		if len(LLVMLd) > 0 {
+			attachCmd = LLVMLd
+		} else {
+			attachCmd = "ld"
+		}
+		attachCmdArgs = []string{"-r", "-keep_private_externs", filename, "-sectcreate", segmentName, sectionName, tmpFile.Name()}
+		attachCmdArgs = append(attachCmdArgs, "-o", filename)
+
+	} else {
+		if len(LLVMObjcopy) > 0 {
+			attachCmd = LLVMObjcopy
+		} else {
+			attachCmd = "objcopy"
+		}
+		attachCmdArgs = []string{"--add-section", sectionName + "=" + tmpFile.Name()}
+		attachCmdArgs = append(attachCmdArgs, filename)
+	}
+
+	// Run the attach command and ignore errors
+	_, nerr := execCmd(attachCmd, attachCmdArgs, "")
+	if nerr != nil {
+		return fmt.Errorf("SectionWrite: %v %v failed because %v", attachCmd, attachCmdArgs, nerr)
+	}
+
+	return nil
+}
+
+// SectionRead reads elf or mach sectionName from filename
+func SectionRead(filename string, sectionName string) (data []byte, err error) {
+	sectionName = platformizeSectionName(sectionName)
+
+	switch platform := runtime.GOOS; platform {
+	case osFREEBSD, osLINUX:
+		objFile, err := elf.Open(filename)
+		if err != nil {
+			return nil, err
+		}
+		section := objFile.Section(sectionName)
+		if section == nil {
+			return nil, err
+		}
+		data, err = section.Data()
+		if err != nil {
+			return nil, err
+		}
+	case osDARWIN:
+		objFile, err := macho.Open(filename)
+		if err != nil {
+			return nil, err
+		}
+		section := objFile.Section(sectionName)
+		if section != nil {
+			return nil, err
+		}
+		data, err = section.Data()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = nil
+	return data, err
+}
+
+func platformizeSectionName(name string) string {
+	switch runtime.GOOS {
+	case osDARWIN:
+		return "__" + name
+	case osLINUX, osFREEBSD:
+		return "." + name
+	default:
+		return "<ERROR>"
+	}
+}

--- a/shared/sections.go
+++ b/shared/sections.go
@@ -140,6 +140,6 @@ func PlatformizeSectionName(name string) string {
 	case osLINUX, osFREEBSD:
 		return "." + name
 	default:
-		return "<ERROR>"
+		return "." + name
 	}
 }

--- a/tests/aaa_individual_objects_test.go
+++ b/tests/aaa_individual_objects_test.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/SRI-CSL/gllvm/shared"
+)
+
+// gclang -c data/helloworld.c -o helloworld.o
+// gclang -c data/testobj.c -o testobj.o
+// gclang helloworld.o testobj.o -o helloworld2
+
+func Test_individual_objects(t *testing.T) {
+	argss := [][]string{
+		{"-c", "../data/helloworld.c", "-o", "helloworld.o"},
+		{"-c", "../data/testobj.c", "-o", "testobj.o"},
+		{"helloworld.o", "testobj.o", "-o", "../data/helloworld"},
+	}
+
+	for _, args := range argss {
+		exitCode := shared.Compile(args, "clang")
+
+		if exitCode != 0 {
+			t.Errorf("Compile of %v returned %v\n", args, exitCode)
+		} else {
+			fmt.Println("Compiled OK")
+		}
+
+	}
+
+	args := []string{"get-bc", "-v", "../data/helloworld"}
+
+	exitCode := shared.Extract(args)
+
+	if exitCode != 0 {
+		t.Errorf("Extraction of %v returned %v\n", args, exitCode)
+	} else {
+		fmt.Println("Extraction OK")
+	}
+
+}

--- a/tests/aaa_individual_objects_test.go
+++ b/tests/aaa_individual_objects_test.go
@@ -13,9 +13,9 @@ import (
 
 func Test_individual_objects(t *testing.T) {
 	argss := [][]string{
-		{"-c", "../data/helloworld.c", "-o", "helloworld.o"},
-		{"-c", "../data/testobj.c", "-o", "testobj.o"},
-		{"helloworld.o", "testobj.o", "-o", "../data/helloworld"},
+		{"-c", "../data/helloworld.c", "-o", "helloworld2.o"},
+		{"-c", "../data/testobj.c", "-o", "testobj2.o"},
+		{"helloworld2.o", "testobj2.o", "-o", "../data/hello2"},
 	}
 
 	for _, args := range argss {
@@ -29,7 +29,7 @@ func Test_individual_objects(t *testing.T) {
 
 	}
 
-	args := []string{"get-bc", "-v", "../data/helloworld"}
+	args := []string{"get-bc", "-v", "../data/hello2"}
 
 	exitCode := shared.Extract(args)
 

--- a/tests/entry_test.go
+++ b/tests/entry_test.go
@@ -2,12 +2,13 @@ package test
 
 import (
 	"fmt"
-	"github.com/SRI-CSL/gllvm/shared"
 	"testing"
+
+	"github.com/SRI-CSL/gllvm/shared"
 )
 
 func Test_basic_functionality(t *testing.T) {
-	args := []string{"../data/helloworld.c", "-o", "../data/hello"}
+	args := []string{"../data/helloworld.c", "../data/testobj.c", "-o", "../data/hello"}
 
 	exitCode := shared.Compile(args, "clang")
 


### PR DESCRIPTION
The command line arguments used during compilation are saved in the .gllvm_flags section. Each object has a JSON line for how it was compiled, and the final executable has a JSONL blob of all its objects.